### PR TITLE
Data source, spring session, and port number for the API

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
+server.port=8082
 
+spring.datasource.url=jdbc:mysql://localhost:3306/just_tech_news_java_db?useSSL=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.session.store-type=jdbc
+spring.session.jdbc.initialize-schema=always
+spring.session.timeout.seconds=600
+spring.h2.console.enabled=true


### PR DESCRIPTION
This update configures the data source, spring session, and port number for the API. These settings are explained by the following text:

[for lines 1-8]
First we pick a port. In this case, we'll use 8082. The next variable will be the data source URL. This URL is called a connection string. First we specify the jdbc as mysql, then provide a string of parameters for the MySQL connection. We'll be testing locally, so we pass in localhost and what we want to name the database, localhost:3306/just_tech_news_java_db. We'll chain parameters, starting with useSSL set to false; the serverTimezone will be UTC; and most importantly, we want to create the database if it doesn't exist, so we pass createDatabaseIfNotExist=true. We also want to set up the database with the ability for the client to request the public key from the server.

Additionally, you'll need to change the username and password to whatever is set up on YOUR machine, and you'll need to set up the way the schema tools will manipulate the database at startup (hibernate.ddl-auto=update).

Note the value we gave our password. Does that format look familiar to you? It's the same format we use for template literals in JavaScript, but here we're using it to set our password in an environment variable. When deploying to Heroku, we'll use Heroku's settings to set environment variables, but locally, we'll use IntelliJ to set our database password. This allows us to push our code to GitHub without publishing sensitive data, which we'll do shortly.

Lastly, we'll have the JPA dump out the SQL statements (show-sql=true), and the final variable (properties.hibernate.format_sql) will make these statements more readable!

[for lines 10-13]
We set the store-type as jdbc, stating that we want to initialize the schema every time we start up the session. We set timeout to six seconds for this example, but it can be set to any length of time. Finally, we enabled the H2 console, an embedded GUI console for browsing the contents of a database and running the queries.