### PR TITLE
Fixes session bug from deprecated code

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,5 +9,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.session.store-type=jdbc
 spring.session.jdbc.initialize-schema=always
-spring.session.timeout.seconds=600
+server.servlet.session.timeout=600s
 spring.h2.console.enabled=true


### PR DESCRIPTION
This update fixes a bug that did not allow the Java  API to start up and thus prevented the creation of the database table. The instructions provided were to use `springe.session.timeout.seconds=600` in the `application.properties` file. However, according to [Daryl from Stack Overflow](https://stackoverflow.com/users/7798982/daryl), this [code is now deprecated](https://stackoverflow.com/questions/40974955/spring-boot-java-config-set-session-timeout) and has been changed to use `server.servlet.session.timeout=600s` as a replacement.

After checking MySQL Workbench, the database table creation has been confirmed.