### PR TITLE
Adds homepage template and refactors location of layout template

### DIFF
--- a/src/main/resources/templates/homepage.html
+++ b/src/main/resources/templates/homepage.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<head>
+  <title>Homepage</title>
+</head>
+
+<body>
+
+<div layout:fragment="content">
+  <ol>
+    <li th:each="post : ${postList}" class="post-list">
+      <div th:insert="fragments/post-fragment :: post-fragment"></div>
+    </li>
+  </ol>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title layout:title-pattern="$CONTENT_TITLE - $LAYOUT_TITLE">Just Tech News</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<div class="wrapper">
+    <header>
+        <h1>
+            <a href="/">Just Tech News</a>
+        </h1>
+        <nav>
+            <div th:if="${loggedIn}">
+                <a th:href="@{/dashboard}">dashboard</a>
+                <a th:href="@{/users/logout}">logout</a>
+            </div>
+            <div th:unless="${loggedIn}">
+                <a th:href="@{/login}">login</a>
+            </div>
+        </nav>
+    </header>
+
+    <main layout:fragment="content">
+        <p>This is filled by the content template.</p>
+    </main>
+
+    <footer>
+        Thanks for visiting!
+    </footer>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This update adds the homepage template and refactors the location of the layout template to the template folder.

- layout:decorate="~{layout}, on line 2 designates that the homepage HTML file will be bound to layout.html.
- line 12 fragment can be thought of as akin to components in React (as far as I know)