### PR TITLE
Adds login and sign up forms

### DIFF
--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <title>Login</title>
+</head>
+
+<body>
+
+<div layout:fragment="content">
+
+    <div th:if="${notice}" class="flash-message">
+        <h3>[[${notice}]]</h3>
+    </div>
+
+    <form action="#" th:action="@{/users/login}" th:object="${user}" method="post" class="login-form">
+        <div>
+            <label>email:</label>
+            <input type="text" th:field="*{email}"/>
+        </div>
+        <div>
+            <label>password:</label>
+            <input type="password" th:field="*{password}"/>
+        </div>
+        <div>
+            <button type="submit">login</button>
+        </div>
+    </form>
+
+
+
+    <form action="#" th:action="@{/users}" th:object="${user}" method="post" class="signup-form">
+        <div>
+            <label>username:</label>
+            <input type="text" th:field="*{username}"/>
+        </div>
+        <div>
+            <label>email:</label>
+            <input type="text" th:field="*{email}"/>
+        </div>
+        <div>
+            <label>password:</label>
+            <input type="password" th:field="*{password}"/>
+        </div>
+        <div>
+            <button type="submit">signup</button>
+        </div>
+    </form>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This update adds the login and sign-up form to the templates directory.

Notes about the code:

- In the <form> element, we provide a few Thymeleaf attributes. The th:action="@{/users}" attribute designates the API route for submitting this form; th:object="${user}" designates that the submitted form fields will comprise a user object; and lastly, the method attribute designates it as a POST request. [See line 17 & 33 for example]

- The forms include three input fields, where we designate the type as either text or password and then give a name to the field, via th:field. [See line 20 for example]